### PR TITLE
Add missing Exception import in HSLColor.php

### DIFF
--- a/src/HSLColor.php
+++ b/src/HSLColor.php
@@ -2,6 +2,7 @@
 
 namespace Renfordt\Colors;
 
+use Exception;
 use Renfordt\Colors\Traits\HueBasedTrait;
 
 class HSLColor


### PR DESCRIPTION
This change ensures proper handling of exceptions within the HSLColor class. Without this import, any usage of Exception would result in a fatal error due to the undefined class.

Fixes #1 